### PR TITLE
Changed to build correctly

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenRTF is an open source Java library for RFT files #
+# OpenRTF is an open source Java library for RTF (Rich Text Format) files #
 
 OpenRTF is a Java library for creating and editing RTF (Rich Text Format) files with a LGPL and MPL open source license.  We welcome contributions from other developers. Please feel free to submit pull-requests and bugreports to this GitHub repository.
 
@@ -24,6 +24,3 @@ Make sure that your contributions can be released with a dual LGPL and MPL licen
 ## Dependencies ##
 ### Required Dependencies: ###
  - Java 8 or later is required to use OpenRTF. All versions Java 8 to Java OpenJDK 13 have been tested to work.
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.librepdf</groupId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
     <version>1.4.0-SNAPSHOT</version>
     <artifactId>openrtf</artifactId>
+
+    <name>OpenRTF</name>
 
     <licenses>
         <license>
@@ -30,6 +32,13 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <!-- OpenRTF depends on RtfElementInterface from OpenPDF. -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>openpdf</artifactId>
+            <version>1.3.13</version>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -37,14 +46,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>openpdf</artifactId>
-            <version>1.3.13</version>
-            <scope>test</scope>
-        </dependency>
-             
     </dependencies>
 
     <developers>
@@ -60,5 +61,4 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/lowagie/text/rtf/document/CreateSimpleRTFDocumentTest.java
+++ b/src/test/java/com/lowagie/text/rtf/document/CreateSimpleRTFDocumentTest.java
@@ -1,0 +1,64 @@
+/*
+ * CreateSimpleRTFDocumentTest.java
+ */
+package com.lowagie.text.rtf.document;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.Table;
+import com.lowagie.text.rtf.RtfWriter2;
+import com.lowagie.text.rtf.style.RtfFont;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * Test creation of a simple RTF document.
+ *
+ * @author <A HREF="mailto:cursor42@gmx.de">Chris</A>
+ */
+public class CreateSimpleRTFDocumentTest {
+
+    @Test
+    public void createDocument() throws FileNotFoundException {
+        
+        final File OUTPUT_FILE = new File("target/CreateSimpleRTFDocumentTest.rtf");
+
+        // Delete output file if it already exists
+        if (OUTPUT_FILE.exists()) {
+            assertTrue ("Could NOT delete existing output file!", OUTPUT_FILE.delete());
+        }
+
+        // Create a document using A4 paper format
+        Document document = new Document(PageSize.A4);
+        RtfWriter2 rtf = RtfWriter2.getInstance(document, new FileOutputStream(OUTPUT_FILE));
+        document.open();
+        document.setMargins(50, 50, 50, 50);
+
+        // Add a paragraph with some text.
+        document.add(new Paragraph("Just a test to write RTF!", new RtfFont("SansSerif", 14, RtfFont.BOLD)));
+
+        // Add a table with 2 columns.
+        RtfFont headerFont = new RtfFont("SansSerif", 10, RtfFont.BOLD);
+        RtfFont tableFont = new RtfFont("SansSerif", 9);
+        int[] aWidths = {10,10};
+        Table table = new Table(2);
+        table.setWidth(80);
+        table.setWidths(aWidths);
+        table.addCell(new Phrase("Column", headerFont));
+        table.addCell(new Phrase("Another Column", headerFont));        
+        table.addCell(new Phrase("Table data", tableFont));
+        table.addCell(new Phrase("Other data", tableFont));        
+        table.addCell(new Phrase("Another row..", tableFont));
+        table.addCell(new Phrase("with data", tableFont));
+        document.add(table);
+
+        // Write document to OUTPUT_FILE.
+        rtf.close();
+        assertTrue ("RTF document was NOT created!", OUTPUT_FILE.exists());
+    }    
+}


### PR DESCRIPTION
Hi again,

I had to add OpenPDF dependency again to build correctly. The packaging in pom.xml was "POM" - I changed this to "JAR" to enabled to build process.

I also added a simple test in the test packages to show how we used itext-rtf in the past.

Maybe change spelling of your project to "OpenRTF" (like OpenPDF), too?

Best regards,

Chris

