### PR TITLE
Remove deprecated method usage

### DIFF
--- a/src/main/java/com/lowagie/text/rtf/RtfMapper.java
+++ b/src/main/java/com/lowagie/text/rtf/RtfMapper.java
@@ -130,12 +130,12 @@ public class RtfMapper {
     		case Element.CHUNK:
     		    Chunk chunk = (Chunk) element;
     		    if(chunk.hasAttributes()) {
-    		        if(chunk.getAttributes().containsKey(Chunk.IMAGE)) {
+    		        if(chunk.getChunkAttributes().containsKey(Chunk.IMAGE)) {
     		            rtfElements.add(new RtfImage(rtfDoc, chunk.getImage()));
-    		        } else if(chunk.getAttributes().containsKey(Chunk.NEWPAGE)) {
+    		        } else if(chunk.getChunkAttributes().containsKey(Chunk.NEWPAGE)) {
     		            rtfElements.add(new RtfNewPage(rtfDoc));
-    		        } else if(chunk.getAttributes().containsKey(Chunk.TAB)) {
-                        Float tabPos = (Float) ((Object[]) chunk.getAttributes().get(Chunk.TAB))[1];
+    		        } else if(chunk.getChunkAttributes().containsKey(Chunk.TAB)) {
+                        Float tabPos = (Float) ((Object[]) chunk.getChunkAttributes().get(Chunk.TAB))[1];
                         RtfTab tab = new RtfTab(tabPos.floatValue(), RtfTab.TAB_LEFT_ALIGN);
                         tab.setRtfDocument(rtfDoc);
                         rtfElements.add(tab);

--- a/src/main/java/com/lowagie/text/rtf/document/RtfDocument.java
+++ b/src/main/java/com/lowagie/text/rtf/document/RtfDocument.java
@@ -222,7 +222,7 @@ public class RtfDocument extends RtfElement {
         Integer newInt = null;
         do {
 //        	do {
-        		newInt = new Integer((int) (Math.random() * Integer.MAX_VALUE));
+        		newInt = (int) (Math.random() * Integer.MAX_VALUE);
 //        	} while(newInt.intValue() <= -1 && newInt.intValue() >= -5);
         } while(this.previousRandomInts.contains(newInt));
         this.previousRandomInts.add(newInt);

--- a/src/main/java/com/lowagie/text/rtf/graphic/RtfShapeProperty.java
+++ b/src/main/java/com/lowagie/text/rtf/graphic/RtfShapeProperty.java
@@ -151,7 +151,7 @@ public class RtfShapeProperty extends RtfAddableElement {
      * @param value The long value to use.
      */
 	public RtfShapeProperty(String name, long value) {
-		this(name, new Long(value));
+		this(name, Long.valueOf(value));
 		this.type = PROPERTY_TYPE_LONG;
 	}
 	
@@ -162,7 +162,7 @@ public class RtfShapeProperty extends RtfAddableElement {
      * @param value The double value to use.
      */
 	public RtfShapeProperty(String name, double value) {
-		this(name, new Double(value));
+		this(name, Double.valueOf(value));
 		this.type = PROPERTY_TYPE_DOUBLE;
 	}
 	

--- a/src/main/java/com/lowagie/text/rtf/parser/ctrlwords/RtfCtrlWordData.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/ctrlwords/RtfCtrlWordData.java
@@ -110,7 +110,7 @@ public class RtfCtrlWordData implements Cloneable {
 	 */
 	public Integer toInteger() {
 		Integer value;
-		value = new Integer(this.isNeg ? Integer.parseInt(this.param)*-1 : Integer.parseInt(this.param));
+		value = this.isNeg ? Integer.parseInt(this.param)*-1 : Integer.parseInt(this.param);
 		return value;
 	}
 	
@@ -135,7 +135,7 @@ public class RtfCtrlWordData implements Cloneable {
 	 */
 	public Long toLong() {
 		Long value;
-		value = new Long(this.isNeg ? Long.parseLong(this.param)*-1 : Long.parseLong(this.param));
+		value = this.isNeg ? Long.parseLong(this.param)*-1 : Long.parseLong(this.param);
 		return value;
 	}
 	

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationMgr.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationMgr.java
@@ -48,6 +48,7 @@
  */
 package com.lowagie.text.rtf.parser.destinations;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 
 import com.lowagie.text.rtf.parser.RtfParser;
@@ -169,12 +170,8 @@ public final class RtfDestinationMgr {
 			c = (RtfDestination)destinationObjects.get(value.getName());		
 		} else {
 			try {
-				c = (RtfDestination)value.newInstance();
-			} catch (InstantiationException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-				return false;
-			} catch (IllegalAccessException e) {
+				c = (RtfDestination)value.getConstructor().newInstance();
+			} catch (InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 				return false;

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationShppict.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationShppict.java
@@ -113,10 +113,10 @@ public class RtfDestinationShppict extends RtfDestination {
 
 	/* bitapinfo */
 	// wbmbitspixelN - number of bits per pixel - 1 monochrome, 4 16 color, 8 256 color, 24 RGB - Default 1
-	private Integer bitsPerPixel = new Integer(1);
+	private Integer bitsPerPixel = 1;
 
 	// wbmplanesN - number of color planes - must be 1
-	private Integer planes = new Integer(1);
+	private Integer planes = 1;
 
 	// wbmwidthbytesN - number of bytes in each raster line
 	private Integer widthBytes = null;
@@ -136,10 +136,10 @@ public class RtfDestinationShppict extends RtfDestination {
 	private Long desiredHeight = null;
 
 	// picscalexN
-	private Integer scaleX = new Integer(100);
+	private Integer scaleX = 100;
 
 	// picscaleyN
-	private Integer scaleY = new Integer(100);
+	private Integer scaleY = 100;
 
 	// picscaled - macpict setting
 	private Boolean scaled = null;
@@ -151,16 +151,16 @@ public class RtfDestinationShppict extends RtfDestination {
 	private Boolean wordArt = Boolean.FALSE;
 
 	// piccroptN
-	private Integer cropTop = new Integer(0);
+	private Integer cropTop = 0;
 
 	// piccropbN
-	private Integer cropBottom = new Integer(0);
+	private Integer cropBottom = 0;
 
 	// piccroplN
-	private Integer cropLeft = new Integer(0);
+	private Integer cropLeft = 0;
 
 	// piccroprN
-	private Integer cropRight = new Integer(0);
+	private Integer cropRight = 0;
 
 	/* metafileinfo */
 	// picbmp
@@ -665,15 +665,15 @@ public class RtfDestinationShppict extends RtfDestination {
 		this.height = null;
 		this.desiredWidth = null;
 		this.desiredHeight = null;
-		this.scaleX = new Integer(100);
-		this.scaleY = new Integer(100);
+		this.scaleX = 100;
+		this.scaleY = 100;
 		this.scaled = null;
 		this.inlinePicture = Boolean.FALSE;
 		this.wordArt = Boolean.FALSE;
-		this.cropTop = new Integer(0);
-		this.cropBottom = new Integer(0);
-		this.cropLeft = new Integer(0);
-		this.cropRight = new Integer(0);
+		this.cropTop = 0;
+		this.cropBottom = 0;
+		this.cropLeft = 0;
+		this.cropRight = 0;
 		this.bitmap = false;
 		this.bbp = 1;
 		this.dataFormat = FORMAT_HEXADECIMAL;

--- a/src/main/java/com/lowagie/text/rtf/parser/properties/RtfProperty.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/properties/RtfProperty.java
@@ -254,7 +254,7 @@ public class RtfProperty {
 		
 		Object propertyValue = getProperty(propertyName);
 		if(propertyValue == null) {
-			propertyValue = new Integer(RtfProperty.ON);
+			propertyValue = RtfProperty.ON;
 		} else {
 			if(propertyValue instanceof Integer) {
 				int value = ((Integer)propertyValue).intValue();
@@ -333,7 +333,7 @@ public class RtfProperty {
 			if (valueOld==propertyValueNew) return true;
 		} 
 		beforeChange(propertyName);
-		properties.put(propertyName, new Integer(propertyValueNew));
+		properties.put(propertyName, propertyValueNew);
 		afterChange(propertyName);
 		setModified(propertyName, true);
 		return true;
@@ -351,7 +351,7 @@ public class RtfProperty {
 		if((value | propertyValue) == value) return true;
 		value |= propertyValue;
 		beforeChange(propertyName);
-		properties.put(propertyName, new Integer(value));
+		properties.put(propertyName, value);
 		afterChange(propertyName);
 		setModified(propertyName, true);
 		return true;
@@ -371,7 +371,7 @@ public class RtfProperty {
 			if (valueOld==propertyValueNew) return true;
 		} 
 		beforeChange(propertyName);
-		properties.put(propertyName, new Long(propertyValueNew));
+		properties.put(propertyName, propertyValueNew);
 		afterChange(propertyName);
 		setModified(propertyName, true);
 		return true;
@@ -389,7 +389,7 @@ public class RtfProperty {
 		if((value | propertyValue) == value) return true;
 		value |= propertyValue;
 		beforeChange(propertyName);
-		properties.put(propertyName, new Long(value));
+		properties.put(propertyName, value);
 		afterChange(propertyName);
 		setModified(propertyName, true);
 		return true;

--- a/src/main/java/com/lowagie/text/rtf/table/RtfBorderGroup.java
+++ b/src/main/java/com/lowagie/text/rtf/table/RtfBorderGroup.java
@@ -148,7 +148,7 @@ public class RtfBorderGroup extends RtfElement {
      */
     private void setBorder(int borderPosition, int borderStyle, float borderWidth, Color borderColor) {
         RtfBorder border = new RtfBorder(this.document, this.borderType, borderPosition, borderStyle, borderWidth, borderColor);
-        this.borders.put(new Integer(borderPosition), border);
+        this.borders.put(borderPosition, border);
     }
     
     /**
@@ -185,20 +185,20 @@ public class RtfBorderGroup extends RtfElement {
      */
     public void removeBorder(int bordersToRemove) {
         if((bordersToRemove & Rectangle.LEFT) == Rectangle.LEFT) {
-            this.borders.remove(new Integer(RtfBorder.LEFT_BORDER));
+            this.borders.remove(RtfBorder.LEFT_BORDER);
         }
         if((bordersToRemove & Rectangle.TOP) == Rectangle.TOP) {
-            this.borders.remove(new Integer(RtfBorder.TOP_BORDER));
+            this.borders.remove(RtfBorder.TOP_BORDER);
         }
         if((bordersToRemove & Rectangle.RIGHT) == Rectangle.RIGHT) {
-            this.borders.remove(new Integer(RtfBorder.RIGHT_BORDER));
+            this.borders.remove(RtfBorder.RIGHT_BORDER);
         }
         if((bordersToRemove & Rectangle.BOTTOM) == Rectangle.BOTTOM) {
-            this.borders.remove(new Integer(RtfBorder.BOTTOM_BORDER));
+            this.borders.remove(RtfBorder.BOTTOM_BORDER);
         }
         if((bordersToRemove & Rectangle.BOX) == Rectangle.BOX && this.borderType == RtfBorder.ROW_BORDER) {
-            this.borders.remove(new Integer(RtfBorder.VERTICAL_BORDER));
-            this.borders.remove(new Integer(RtfBorder.HORIZONTAL_BORDER));
+            this.borders.remove(RtfBorder.VERTICAL_BORDER);
+            this.borders.remove(RtfBorder.HORIZONTAL_BORDER);
         }
     }
     

--- a/src/main/java/com/lowagie/text/rtf/text/RtfChunk.java
+++ b/src/main/java/com/lowagie/text/rtf/text/RtfChunk.java
@@ -122,11 +122,11 @@ public class RtfChunk extends RtfElement {
             return;
         }
         
-        if(chunk.getAttributes() != null && chunk.getAttributes().get(Chunk.SUBSUPSCRIPT) != null) {
-            this.superSubScript = ((Float)chunk.getAttributes().get(Chunk.SUBSUPSCRIPT)).floatValue();
+        if(chunk.getChunkAttributes() != null && chunk.getChunkAttributes().get(Chunk.SUBSUPSCRIPT) != null) {
+            this.superSubScript = ((Float)chunk.getChunkAttributes().get(Chunk.SUBSUPSCRIPT)).floatValue();
         }
-        if(chunk.getAttributes() != null && chunk.getAttributes().get(Chunk.BACKGROUND) != null) {
-            this.background = new RtfColor(this.document, (Color) ((Object[]) chunk.getAttributes().get(Chunk.BACKGROUND))[0]);
+        if(chunk.getChunkAttributes() != null && chunk.getChunkAttributes().get(Chunk.BACKGROUND) != null) {
+            this.background = new RtfColor(this.document, (Color) ((Object[]) chunk.getChunkAttributes().get(Chunk.BACKGROUND))[0]);
         }
         font = new RtfFont(doc, chunk.getFont());
         content = chunk.getContent();


### PR DESCRIPTION
Following methods have been deprecated in Java 9:
1. Primitive wrapper constructors
2. Class.newInstance

Also openpdf's Chunk.getAttributes has been deprecated in favor of getChunkAttributes.

This patch changes deprecated methods to their appropriate replacements.