### PR TITLE
Use of collection interfaces

### DIFF
--- a/src/main/java/com/lowagie/text/rtf/RtfAddableElement.java
+++ b/src/main/java/com/lowagie/text/rtf/RtfAddableElement.java
@@ -88,7 +88,7 @@ public abstract class RtfAddableElement extends Chunk implements RtfBasicElement
 	 * Constructs a new RtfAddableElement. The Chunk content is
 	 * set to an empty string and the font to the default Font().
 	 */
-	protected RtfAddableElement() {
+	public RtfAddableElement() {
 		super("", new Font());
 	}
 

--- a/src/main/java/com/lowagie/text/rtf/RtfElement.java
+++ b/src/main/java/com/lowagie/text/rtf/RtfElement.java
@@ -81,7 +81,7 @@ public abstract class RtfElement implements RtfBasicElement {
      * 
      * @param doc The RtfDocument this RtfElement belongs to
      */
-    protected RtfElement(RtfDocument doc) {
+    public RtfElement(RtfDocument doc) {
         this.document = doc;
     }
 

--- a/src/main/java/com/lowagie/text/rtf/RtfMapper.java
+++ b/src/main/java/com/lowagie/text/rtf/RtfMapper.java
@@ -125,7 +125,7 @@ public class RtfMapper {
             return new RtfBasicElement[]{rtfElement};
         }
 
-		ArrayList<RtfBasicElement> rtfElements = new ArrayList<>();
+		java.util.List<RtfBasicElement> rtfElements = new ArrayList<>();
 		switch(element.type()) {
     		case Element.CHUNK:
     		    Chunk chunk = (Chunk) element;

--- a/src/main/java/com/lowagie/text/rtf/document/RtfDocument.java
+++ b/src/main/java/com/lowagie/text/rtf/document/RtfDocument.java
@@ -52,6 +52,8 @@ package com.lowagie.text.rtf.document;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
+
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocWriter;
@@ -90,7 +92,7 @@ public class RtfDocument extends RtfElement {
     /**
      * Stores integers that have been generated as unique random numbers
      */
-    private final ArrayList<Integer> previousRandomInts = new ArrayList<>();
+    private final List<Integer> previousRandomInts = new ArrayList<>();
     /**
      * Whether to automatically generate TOC entries for Chapters and Sections. Defaults to false
      */

--- a/src/main/java/com/lowagie/text/rtf/document/RtfInfoGroup.java
+++ b/src/main/java/com/lowagie/text/rtf/document/RtfInfoGroup.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.document;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.rtf.RtfElement;
@@ -81,7 +82,7 @@ public class RtfInfoGroup extends RtfElement {
     /**
      * The RtfInfoElements that belong to this RtfInfoGroup
      */
-    private final ArrayList<RtfInfoElement> infoElements = new ArrayList<>();
+    private final List<RtfInfoElement> infoElements = new ArrayList<>();
     
     /**
      * Constructs a RtfInfoGroup belonging to a RtfDocument

--- a/src/main/java/com/lowagie/text/rtf/graphic/RtfShape.java
+++ b/src/main/java/com/lowagie/text/rtf/graphic/RtfShape.java
@@ -3,6 +3,7 @@ package com.lowagie.text.rtf.graphic;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.rtf.RtfAddableElement;
@@ -182,7 +183,7 @@ public class RtfShape extends RtfAddableElement {
     /**
      * A HashMap with RtfShapePropertys that define further shape properties.
      */
-	private final HashMap<String, RtfShapeProperty> properties = new HashMap<>();
+	private final Map<String, RtfShapeProperty> properties = new HashMap<>();
     /**
      * The wrapping mode. Defaults to SHAPE_WRAP_NONE;
      */

--- a/src/main/java/com/lowagie/text/rtf/list/RtfList.java
+++ b/src/main/java/com/lowagie/text/rtf/list/RtfList.java
@@ -161,7 +161,7 @@ public class RtfList extends RtfElement implements RtfExtendedElement {
     /**
      * The subitems of this RtfList
      */
-    private ArrayList<RtfBasicElement> items;
+    private java.util.List<RtfBasicElement> items;
     
     /**
      * The parent list if there is one.
@@ -209,7 +209,7 @@ public class RtfList extends RtfElement implements RtfExtendedElement {
     /**
      * The RtfList lists managed by this RtfListTable
      */
-    private final ArrayList<RtfListLevel> listLevels = new ArrayList<>();
+    private final java.util.List<RtfListLevel> listLevels = new ArrayList<>();
 
 
     /**

--- a/src/main/java/com/lowagie/text/rtf/list/RtfListTable.java
+++ b/src/main/java/com/lowagie/text/rtf/list/RtfListTable.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.list;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.rtf.RtfElement;
@@ -89,11 +90,11 @@ public class RtfListTable extends RtfElement implements RtfExtendedElement {
     /**
      * The RtfList lists managed by this RtfListTable
      */
-    private final ArrayList<RtfList> lists = new ArrayList<>();
+    private final List<RtfList> lists = new ArrayList<>();
     /**
      * The RtfPictureList lists managed by this RtfListTable
      */
-    private final ArrayList<RtfPictureList> picturelists = new ArrayList<>();
+    private final List<RtfPictureList> picturelists = new ArrayList<>();
     
     /**
      * Constructs a RtfListTable for a RtfDocument

--- a/src/main/java/com/lowagie/text/rtf/parser/RtfImportMgr.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/RtfImportMgr.java
@@ -51,6 +51,7 @@ package com.lowagie.text.rtf.parser;
 
 import java.awt.Color;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.List;
@@ -78,19 +79,19 @@ public class RtfImportMgr {
     /**
      * The HashMap storing the font number mappings.
      */
-    private final HashMap<String, String> importFontMapping = new HashMap<>();
+    private final Map<String, String> importFontMapping = new HashMap<>();
     /**
      * The HashMap storing the color number mappings.
      */
-    private final HashMap<String, String> importColorMapping = new HashMap<>();
+    private final Map<String, String> importColorMapping = new HashMap<>();
     /**
      * The HashMap storing the Stylesheet List number mappings.
      */
-    private final HashMap<String, String> importStylesheetListMapping = new HashMap<>();
+    private final Map<String, String> importStylesheetListMapping = new HashMap<>();
     /**
      * The HashMap storing the List number mappings.
      */
-    private final HashMap<String, String> importListMapping = new HashMap<>();
+    private final Map<String, String> importListMapping = new HashMap<>();
     /**
      * The RtfDocument to get font and color numbers from.
      */

--- a/src/main/java/com/lowagie/text/rtf/parser/RtfParser.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/RtfParser.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.EventListener;
 import java.util.Iterator;
+import java.util.List;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
@@ -457,7 +458,7 @@ public class RtfParser {
 	private RtfCtrlWordData lastCtrlWordParam = null;
 	
 	/** The <code>RtfCtrlWordListener</code>. */
-    private final ArrayList<EventListener> listeners = new ArrayList<>();
+    private final List<EventListener> listeners = new ArrayList<>();
     
 	/**
 	 * Constructor 

--- a/src/main/java/com/lowagie/text/rtf/parser/ctrlwords/RtfCtrlWordMap.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/ctrlwords/RtfCtrlWordMap.java
@@ -49,6 +49,7 @@
 package com.lowagie.text.rtf.parser.ctrlwords;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.rtf.parser.RtfParser;
 import com.lowagie.text.rtf.parser.properties.RtfProperty;
@@ -71,7 +72,7 @@ final class RtfCtrlWordMap {
     /**
      * Control Word HashMap mapping object.
      */
-    private final HashMap<String, RtfCtrlWordHandler> ctrlWords = new HashMap<>(2012, .9f);
+    private final Map<String, RtfCtrlWordHandler> ctrlWords = new HashMap<>(2012, .9f);
 
     /**
      * Get the HashMap object containing the control words.

--- a/src/main/java/com/lowagie/text/rtf/parser/ctrlwords/RtfCtrlWordMgr.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/ctrlwords/RtfCtrlWordMgr.java
@@ -51,6 +51,7 @@ package com.lowagie.text.rtf.parser.ctrlwords;
 
 import java.io.PushbackInputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.rtf.parser.RtfParser;
 
@@ -70,7 +71,7 @@ public final class RtfCtrlWordMgr {
 	private final RtfCtrlWordMap ctrlWordMap;
 	
 	/** The <code>RtfCtrlWordListener</code>. */
-    private final ArrayList<RtfCtrlWordListener> listeners = new ArrayList<>();
+    private final List<RtfCtrlWordListener> listeners = new ArrayList<>();
 
 //	// TIMING DEBUG INFO
 //	private long endTime = 0;

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestination.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestination.java
@@ -49,6 +49,7 @@
 package com.lowagie.text.rtf.parser.destinations;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.rtf.parser.RtfParser;
 import com.lowagie.text.rtf.parser.ctrlwords.RtfCtrlWordData;
@@ -72,7 +73,7 @@ public abstract class RtfDestination {
 	protected RtfCtrlWordData lastCtrlWord = null;
 
      /** The <code>RtfDestinationListener</code>. */
-    private static final ArrayList<RtfDestinationListener> listeners = new ArrayList<>();
+    private static final List<RtfDestinationListener> listeners = new ArrayList<>();
     
 	/**
 	 * Constructor.

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestination.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestination.java
@@ -77,14 +77,14 @@ public abstract class RtfDestination {
 	/**
 	 * Constructor.
 	 */
-    protected RtfDestination() {
+    public RtfDestination() {
 		rtfParser = null;
 	}
 	/**
 	 * Constructor
 	 * @param parser <code>RtfParser</code> object.
 	 */
-	protected RtfDestination(RtfParser parser) {
+	public RtfDestination(RtfParser parser) {
 		this.rtfParser = parser;
 	}
 	/**

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationColorTable.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationColorTable.java
@@ -50,6 +50,7 @@ package com.lowagie.text.rtf.parser.destinations;
 
 import java.awt.Color;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.rtf.parser.RtfImportMgr;
 import com.lowagie.text.rtf.parser.RtfParser;
@@ -127,7 +128,7 @@ public class RtfDestinationColorTable extends RtfDestination  {
 	/**
 	 * Color map object for conversions
 	 */
-	private HashMap<String, Color> colorMap = new HashMap<>();
+	private Map<String, Color> colorMap = new HashMap<>();
 	
 	/**
 	 * Constructor.

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationDocument.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationDocument.java
@@ -50,8 +50,8 @@ package com.lowagie.text.rtf.parser.destinations;
 
 import java.awt.Color;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
@@ -568,7 +568,7 @@ public final class RtfDestinationDocument extends RtfDestination implements RtfP
 			Chunk chunk = new Chunk();
 			chunk.append(this.buffer.toString());
 			this.buffer = new StringBuilder(255);
-			HashMap<String, Object> charProperties = this.rtfParser.getState().properties.getProperties(RtfProperty.CHARACTER);
+			Map<String, Object> charProperties = this.rtfParser.getState().properties.getProperties(RtfProperty.CHARACTER);
 			String defFont = (String)charProperties.get(RtfProperty.CHARACTER_FONT);
 			if(defFont == null) defFont = "0";
 			RtfDestinationFontTable fontTable = (RtfDestinationFontTable)this.rtfParser.getDestination("fonttbl");

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationFontTable.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationFontTable.java
@@ -157,7 +157,7 @@ public final class RtfDestinationFontTable extends RtfDestination {
 	/**
 	 * Convert font mapping to <code>FontFactory</code> font objects.
 	 */
-	private HashMap<String, Font> fontMap = null;
+	private Map<String, Font> fontMap = null;
 	
 	/**
 	 * Constructor

--- a/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationMgr.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/destinations/RtfDestinationMgr.java
@@ -50,6 +50,7 @@ package com.lowagie.text.rtf.parser.destinations;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.rtf.parser.RtfParser;
 
@@ -74,12 +75,12 @@ public final class RtfDestinationMgr {
 	 * discarding unwanted data. This is primarily used when
 	 * skipping groups, binary data or unwanted/unknown data.
 	 */
-	private static final HashMap<String, RtfDestination> destinations = new HashMap<>(300, 0.95f);
+	private static final Map<String, RtfDestination> destinations = new HashMap<>(300, 0.95f);
 	/**
 	 * Destination objects.
 	 * There is only one of each destination.
 	 */
-	private static final HashMap<String, RtfDestination> destinationObjects = new HashMap<>(10, 0.95f);
+	private static final Map<String, RtfDestination> destinationObjects = new HashMap<>(10, 0.95f);
 	
 	private static boolean ignoreUnknownDestinations = false;
 	

--- a/src/main/java/com/lowagie/text/rtf/parser/properties/RtfProperty.java
+++ b/src/main/java/com/lowagie/text/rtf/parser/properties/RtfProperty.java
@@ -50,6 +50,7 @@ package com.lowagie.text.rtf.parser.properties;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.lowagie.text.rtf.parser.ctrlwords.RtfCtrlWordData;
@@ -166,7 +167,7 @@ public class RtfProperty {
 	public static final String DOCUMENT_DEFAULT_FONT_NUMER = DOCUMENT + "defaultFontNumber";
 	
 	/** Properties for this RtfProperty object */
-	protected final HashMap<String, Object> properties = new HashMap<>();
+	protected final Map<String, Object> properties = new HashMap<>();
 	
 	private boolean modifiedCharacter = false; 
 	private boolean modifiedParagraph = false; 
@@ -175,7 +176,7 @@ public class RtfProperty {
 
 	
 	/** The <code>RtfPropertyListener</code>. */
-    private final ArrayList<RtfPropertyListener> listeners = new ArrayList<>();
+    private final List<RtfPropertyListener> listeners = new ArrayList<>();
 	/**
 	 * Set all property objects to default values.
 	 * @since 2.0.8
@@ -432,7 +433,7 @@ public class RtfProperty {
 		}
 		return props;
 	}
-	
+
 	/**
 	 * @return the modified
 	 */

--- a/src/main/java/com/lowagie/text/rtf/style/RtfColorList.java
+++ b/src/main/java/com/lowagie/text/rtf/style/RtfColorList.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.style;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.rtf.RtfElement;
@@ -77,7 +78,7 @@ public class RtfColorList extends RtfElement implements RtfExtendedElement {
     /**
      * ArrayList containing all colors of this RtfColorList
      */
-    private final ArrayList<RtfColor> colorList = new ArrayList<>();
+    private final List<RtfColor> colorList = new ArrayList<>();
     
     /**
      * Constructs a new RtfColorList for the RtfDocument. Will add the default

--- a/src/main/java/com/lowagie/text/rtf/style/RtfFontList.java
+++ b/src/main/java/com/lowagie/text/rtf/style/RtfFontList.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.style;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.rtf.RtfElement;
@@ -84,7 +85,7 @@ public class RtfFontList extends RtfElement implements RtfExtendedElement {
     /**
      * The list of fonts
      */
-    private final ArrayList<RtfFont> fontList = new ArrayList<>();
+    private final List<RtfFont> fontList = new ArrayList<>();
 
     /**
      * Creates a RtfFontList

--- a/src/main/java/com/lowagie/text/rtf/style/RtfStylesheetList.java
+++ b/src/main/java/com/lowagie/text/rtf/style/RtfStylesheetList.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.style;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.rtf.RtfBasicElement;
@@ -71,7 +72,7 @@ public class RtfStylesheetList extends RtfElement implements RtfExtendedElement 
     /**
      * The HashMap containing the RtfParagraphStyles.
      */
-    private final HashMap<String, RtfParagraphStyle> styleMap = new HashMap<>();
+    private final Map<String, RtfParagraphStyle> styleMap = new HashMap<>();
     /**
      * Whether the default settings have been loaded.
      */

--- a/src/main/java/com/lowagie/text/rtf/table/RtfCell.java
+++ b/src/main/java/com/lowagie/text/rtf/table/RtfCell.java
@@ -107,7 +107,7 @@ public class RtfCell extends Cell implements RtfExtendedElement {
     /**
      * The content of this RtfCell
      */
-    private ArrayList<RtfBasicElement> content = null;
+    private java.util.List<RtfBasicElement> content = null;
     /**
      * The right margin of this RtfCell
      */

--- a/src/main/java/com/lowagie/text/rtf/table/RtfRow.java
+++ b/src/main/java/com/lowagie/text/rtf/table/RtfRow.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.table;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.Cell;
 import com.lowagie.text.DocWriter;
@@ -282,7 +283,7 @@ public class RtfRow extends RtfElement {
                 }
             }
             if(rtfCell.getRowspan() > 1) {
-                ArrayList<RtfRow> rows = this.parentTable.getRows();
+                List<RtfRow> rows = this.parentTable.getRows();
                 for(int j = 1; j < rtfCell.getRowspan(); j++) {
                     RtfRow mergeRow = rows.get(this.rowNumber + j);
                     if(this.rowNumber + j < rows.size()) {

--- a/src/main/java/com/lowagie/text/rtf/text/RtfTabGroup.java
+++ b/src/main/java/com/lowagie/text/rtf/text/RtfTabGroup.java
@@ -54,6 +54,7 @@ package com.lowagie.text.rtf.text;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import com.lowagie.text.rtf.RtfAddableElement;
 import com.lowagie.text.rtf.RtfBasicElement;
@@ -79,7 +80,7 @@ public class RtfTabGroup extends RtfAddableElement {
 	/**
 	 * The tabs to add.
 	 */
-	private final ArrayList<RtfTab> tabs = new ArrayList<>();
+	private final List<RtfTab> tabs = new ArrayList<>();
 
 	/**
 	 * Constructs an empty RtfTabGroup.
@@ -99,7 +100,7 @@ public class RtfTabGroup extends RtfAddableElement {
 			}
 		}
 	}
-	
+
 	/**
 	 * Adds a RtfTab to the list of grouped tabs.
 	 * 


### PR DESCRIPTION
Since we want to preserve binary compatibility with iText, some changes to access modifiers were rolled back from protected to public.
Changes to collections: ArrayList->List, HashMap->Map only for private fields and local variables (for binary compatibility)