### PR TITLE
Use of Map interface instead of HashMap class

### DIFF
--- a/src/main/java/com/lowagie/text/rtf/table/RtfBorderGroup.java
+++ b/src/main/java/com/lowagie/text/rtf/table/RtfBorderGroup.java
@@ -77,7 +77,7 @@ public class RtfBorderGroup extends RtfElement {
     /**
      * The borders in this RtfBorderGroup
      */
-    private final HashMap<Integer, RtfBorder> borders = new HashMap<>();
+    private final Map<Integer, RtfBorder> borders = new HashMap<>();
 
     /**
      * Constructs an empty RtfBorderGroup.
@@ -210,7 +210,7 @@ public class RtfBorderGroup extends RtfElement {
      * 
      * @return The RtfBorders of this RtfBorderGroup
      */
-    protected HashMap<Integer, RtfBorder> getBorders() {
+    protected Map<Integer, RtfBorder> getBorders() {
         return this.borders;
     }
 }


### PR DESCRIPTION
There are binary incompatibilities in RtfBorderGroup protected method getBorders(): its type is changed from the original Hashtable to Map<Integer, RtfBorder>.

Since this method is protected, quite unlikely it is widely used in user code. Is this change OK or it is better to revert to Hashtable?