### PR TITLE
Upgrade openpdf to 1.4.1 and fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <!-- OpenRTF depends on RtfElementInterface from OpenPDF. -->
             <groupId>${project.groupId}</groupId>
             <artifactId>openpdf</artifactId>
-            <version>1.3.26</version>
+            <version>1.4.1</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/src/main/java/com/lowagie/text/rtf/headerfooter/RtfHeaderFooter.java
+++ b/src/main/java/com/lowagie/text/rtf/headerfooter/RtfHeaderFooter.java
@@ -52,6 +52,7 @@ package com.lowagie.text.rtf.headerfooter;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import com.lowagie.text.alignment.HorizontalAlignment;
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
@@ -378,7 +379,7 @@ public class RtfHeaderFooter extends HeaderFooter implements RtfBasicElement {
             if (o instanceof Paragraph) {
                 ((Paragraph) o).setAlignment(alignment);
             } else if (o instanceof Table) {
-                ((Table) o).setAlignment(alignment);
+                ((Table) o).setHorizontalAlignment(HorizontalAlignment.of(alignment).orElse(HorizontalAlignment.UNDEFINED));
             } else if (o instanceof Image) {
                 ((Image) o).setAlignment(alignment);
             }


### PR DESCRIPTION
A little patch not to use deprecated methods from openpdf 1.3.x, which have been removed from 1.4.x. Both 1.3.36 and 1.4.1 can be used to compile with this patch, but it makes upgrade to 1.4.1 possible.