### PR TITLE
Upgrade to newest OpenPDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <!-- OpenRTF depends on RtfElementInterface from OpenPDF. -->
             <groupId>${project.groupId}</groupId>
             <artifactId>openpdf</artifactId>
-            <version>1.4.1</version>
+            <version>2.4.0</version>
         </dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
This looks like it builds and runs mvn verify successfully with the latest 2.4.0